### PR TITLE
Use proper guild ID when adding members

### DIFF
--- a/discord/bot/modals.go
+++ b/discord/bot/modals.go
@@ -66,7 +66,7 @@ func (b *Bot) linkMembershipHadler(s *discordgo.Session, i *discordgo.Interactio
 
 	// Set role
 	for gName, guild := range b.Guilds {
-		err := s.GuildMemberRoleAdd(i.GuildID, i.Member.User.ID, guild.MemberRoleID)
+		err := s.GuildMemberRoleAdd(guild.ID, i.Member.User.ID, guild.MemberRoleID)
 		restErr, ok := err.(*discordgo.RESTError)
 		// skip this guild if member isn't part of it
 		if ok && restErr.Message.Code == unknownMemberErrorCode {


### PR DESCRIPTION
The Discord bot was using the guild (server) ID of the interaction instead of the guild ID from configuration. This meant users were successfully added in the guild where they interacted with the bot, but adding the proper role would fail in the other configured guilds.